### PR TITLE
Hide footer on short viewports

### DIFF
--- a/styles/snake.css
+++ b/styles/snake.css
@@ -1250,6 +1250,12 @@ body.screen-game .gameFooter {
   display: block;
 }
 
+@media (max-height: 720px) {
+  .gameFooter {
+    display: none !important;
+  }
+}
+
 a {
   color: #ffd580;
   text-decoration: none;


### PR DESCRIPTION
### Motivation
- Improve layout on devices with low viewport height so UI elements (like the footer) don't overlap or crowd the game area.
- Provide a simple, CSS-first fix to keep the game view usable on short screens without altering game logic.

### Description
- Added a height-based media query in `styles/snake.css` to target short viewports: `@media (max-height: 720px)`.
- Inside the media query the `.gameFooter` is hidden with `display: none !important;` to ensure it does not overlap the game area.
- The change is limited to CSS only and does not modify JavaScript or game behavior.

### Testing
- Launched a local static server with `python -m http.server` and loaded `index.html` via an automated Playwright script, which ran successfully.
- Playwright navigated to the app and captured `artifacts/footer-hidden.png` at `1280x600` to confirm the footer is hidden, and the capture succeeded.
- The CSS file `styles/snake.css` was added and committed, and no unit tests were required for this static style change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481d6d12848325951ea34c9340c958)